### PR TITLE
create-app: packaging fixes

### DIFF
--- a/packages/create-app/bin/backstage-create-app
+++ b/packages/create-app/bin/backstage-create-app
@@ -21,7 +21,7 @@ const path = require('path');
 const isLocal = require('fs').existsSync(path.resolve(__dirname, '../src'));
 
 if (!isLocal || process.env.BACKSTAGE_E2E_CLI_TEST) {
-  require('../src');
+  require('..');
 } else {
   require('ts-node').register({
     transpileOnly: true,

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -20,6 +20,9 @@
   "bin": {
     "backstage-create-app": "bin/backstage-create-app"
   },
+  "scripts": {
+    "build": "backstage-cli build --outputs cjs"
+  },
   "dependencies": {
     "commander": "^4.1.1",
     "chalk": "^4.0.0",
@@ -36,5 +39,10 @@
     "@types/recursive-readdir": "^2.2.0",
     "@types/ora": "^3.2.0",
     "ts-node": "^8.6.2"
-  }
+  },
+  "files": [
+    "bin",
+    "dist",
+    "templates"
+  ]
 }


### PR DESCRIPTION
This fixes the build issue. The template in the cli still needs to by synced with create-app, since there were some new additions that should be moved over.